### PR TITLE
Add README as long-description

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,8 @@ version = 2.5.0
 author = Michael Hirsch, Ph.D.
 author_email = scivision@users.noreply.github.com
 description = pure Python (no prereqs) coordinate conversions, following convention of several popular Matlab routines.
+long_description = file: README.md
+long_description_content_type = text/markdown
 url = https://github.com/geospace-code/pymap3d
 keywords =
   coordinate conversion


### PR DESCRIPTION
Adds the README to the long-description, which is displayed in pymap3d's PyPI page