### PR TITLE
fix: fix numpy logic bug in ecef2geodetic when some points are inside ellipsoid

### DIFF
--- a/src/pymap3d/ecef.py
+++ b/src/pymap3d/ecef.py
@@ -187,7 +187,7 @@ def ecef2geodetic(
     try:
         if inside.any():  # type: ignore
             # avoid all false assignment bug
-            alt[inside] = -alt
+            alt[inside] = -alt[inside]
     except (TypeError, AttributeError):
         if inside:
             alt = -alt

--- a/src/pymap3d/tests/test_geodetic.py
+++ b/src/pymap3d/tests/test_geodetic.py
@@ -54,6 +54,34 @@ def test_3d_ecef2geodetic():
 
     assert [lat, lon, alt] == approx(lla0, rel=1e-4)
 
+def test_array_ecef2geodetic():
+    """
+    tests ecef2geodetic can handle numpy array data in addition to singular floats
+    """
+    np = pytest.importorskip("numpy")
+    # test values with no points inside ellipsoid
+    lla0_array = (
+        np.array([lla0[0], lla0[0]]), np.array([lla0[1], lla0[1]]), np.array([lla0[2], lla0[2]])
+        )
+    xyz = pm.geodetic2ecef(*lla0_array)
+    lats, lons, alts = pm.ecef2geodetic(*xyz)
+
+    np.testing.assert_almost_equal(lats, lla0_array[0])
+    np.testing.assert_almost_equal(lons, lla0_array[1])
+    np.testing.assert_almost_equal(alts, lla0_array[2])
+
+    # test values with some (but not all) points inside ellipsoid
+    lla0_array_inside = (
+        np.array([lla0[0], lla0[0]]), np.array([lla0[1], lla0[1]]), np.array([lla0[2], -lla0[2]])
+        )
+    xyz = pm.geodetic2ecef(*lla0_array_inside)
+    lats, lons, alts = pm.ecef2geodetic(*xyz)
+
+    np.testing.assert_almost_equal(lats, lla0_array_inside[0])
+    np.testing.assert_almost_equal(lons, lla0_array_inside[1])
+    np.testing.assert_almost_equal(alts, lla0_array_inside[2])
+
+
 
 def test_xarray():
     xarray = pytest.importorskip("xarray")


### PR DESCRIPTION
In the function `ecef2geodetic`, if array data is passed for x, y, and z points (i.e. multiple pairwise points to convert to geodetic), a NumPy logic bug causes a failure if some but not all of those points are inside the ellipsoid.

Error example:
```
Traceback (most recent call last):
  File "/Users/dschurman/Documents/pymap3d/src/pymap3d/ecef.py", line 190, in ecef2geodetic
    alt[inside] = -alt
ValueError: NumPy boolean array indexing assignment cannot assign 2 input values to the 1 output values where the mask is true
```

This PR includes a simple one-liner bugfix, as well as a test to catch this case in the future.