### PR TITLE
Fix of loxodrome_inverse in v2.7.1 which fails with 2d arrays and scalars

### DIFF
--- a/src/pymap3d/lox.py
+++ b/src/pymap3d/lox.py
@@ -13,6 +13,7 @@ try:
         pi,
         array,
         atleast_1d,
+        broadcast_arrays,
         broadcast_to,
     )
 except ImportError:
@@ -150,28 +151,7 @@ def loxodrome_inverse(
         lat1, lon1, lat2, lon2 = radians(lat1), radians(lon1), radians(lat2), radians(lon2)
 
     try:
-        lat1 = atleast_1d(lat1)
-        lon1 = atleast_1d(lon1)
-        lat2 = atleast_1d(lat2)
-        lon2 = atleast_1d(lon2)
-
-        if lat1.shape != lon1.shape:
-            if lat1.size == 1:
-                lat1 = broadcast_to(lat1, lon1.shape)
-            elif lon1.size == 1:
-                lon1 = broadcast_to(lon1, lat1.shape)
-            else:
-                raise ValueError("lat1, lon1 must have same shape")
-        if lat2.shape != lon2.shape:
-            if lat2.size == 1:
-                lat2 = broadcast_to(lat2, lon2.shape)
-            elif lon2.size == 1:
-                lon2 = broadcast_to(lon2, lat2.shape)
-            else:
-                raise ValueError("lat2, lon2 must have same shape")
-        if lat2.shape != lat1.shape:
-            lat2 = broadcast_to(lat2, lat1.shape)
-            lon2 = broadcast_to(lon2, lat1.shape)
+        lat1, lon1, lat2, lon2 = broadcast_arrays(lat1, lon1, lat2, lon2)
 
     except NameError:
         pass

--- a/src/pymap3d/tests/test_rhumb.py
+++ b/src/pymap3d/tests/test_rhumb.py
@@ -76,6 +76,25 @@ def test_numpy_loxodrome_inverse():
     d, a = lox.loxodrome_inverse([40, 40], [-80, -80], 65, [-148, -148])
 
 
+def test_numpy_2d_loxodrome_inverse():
+    pytest.importorskip("numpy")
+    d, a = lox.loxodrome_inverse(
+        [[40, 40], [40, 40]], [[-80, -80], [-80, -80]], 65, -148
+    )
+    assert d == approx(5248666.209)
+    assert a == approx(302.00567)
+
+    d, a = lox.loxodrome_inverse(
+        [[40, 40], [40, 40]], [[-80, -80], [-80, -80]], [[65, 65], [65, 65]], -148
+    )
+    d, a = lox.loxodrome_inverse(
+        [[40, 40], [40, 40]], [[-80, -80], [-80, -80]], 65, [[-148, -148], [-148, -148]]
+    )
+    d, a = lox.loxodrome_inverse(
+        40, -80, [[65, 65], [65, 65]], [[-148, -148], [-148, -148]]
+    )
+
+
 @pytest.mark.parametrize(
     "lat0,lon0,rng,az,lat1,lon1",
     [


### PR DESCRIPTION
Closes #44.

This PR uses simply numpy.broadcast_arrays to make arguments have the same shapes.