### PR TITLE
Bugfix for ecef2geodetic on pole edge cases.

### DIFF
--- a/src/pymap3d/ecef.py
+++ b/src/pymap3d/ecef.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 
 try:
-    from numpy import radians, sin, cos, tan, arctan as atan, hypot, degrees, arctan2 as atan2, sqrt
+    from numpy import radians, sin, cos, tan, arctan as atan, hypot, degrees, arctan2 as atan2, sqrt, finfo, where
     from .eci import eci2ecef, ecef2eci
 except ImportError:
     from math import radians, sin, cos, tan, atan, hypot, degrees, atan2, sqrt  # type: ignore
@@ -153,6 +153,12 @@ def ecef2geodetic(
     Beta += eps
     # %% final output
     lat = atan(ell.semimajor_axis / ell.semiminor_axis * tan(Beta))
+    try:
+        lim_pi2 = pi / 2 - 3 * finfo(eps.dtype).eps
+        lat = where(Beta >= lim_pi2, pi / 2, lat)
+        lat = where(Beta <= -lim_pi2, -pi / 2, lat)
+    except (TypeError, AttributeError, NameError):
+        pass
 
     lon = atan2(y, x)
 

--- a/src/pymap3d/tests/test_geodetic.py
+++ b/src/pymap3d/tests/test_geodetic.py
@@ -15,6 +15,14 @@ B = ELL.semiminor_axis
 
 atol_dist = 1e-6  # 1 micrometer
 
+xyz2lla_testsets = [
+    ((A / 2, 0, 0), (0, 0, -A / 2)),
+    ((0, A / 2, 0), (0, 90, -A / 2)),
+    ((0, 0, B / 2), (90, 0, -B / 2)),
+    ((0, 0, -B / 2), (-90, 0, -B / 2)),
+    ((-A / 2, 0, 0), (0, 180, - A / 2)),
+]
+
 
 @pytest.mark.parametrize("lla", [(42, -82, 200), ([42], [-82], [200])], ids=("scalar", "list"))
 def test_scalar_geodetic2ecef(lla):
@@ -153,19 +161,25 @@ def test_geodetic2ecef(lla, xyz):
 
 @pytest.mark.parametrize(
     "xyz, lla",
-    [
-        ((A - 1, 0, 0), (0, 0, -1)),
-        ((0, A - 1, 0), (0, 90, -1)),
-        ((0, 0, B - 1), (90, 0, -1)),
-        ((0, 0, -B + 1), (-90, 0, -1)),
-        ((-A + 1, 0, 0), (0, 180, -1)),
-    ],
+    xyz2lla_testsets
 )
 def test_ecef2geodetic(xyz, lla):
     lat, lon, alt = pm.ecef2geodetic(*xyz)
     assert lat == approx(lla[0])
     assert lon == approx(lla[1])
     assert alt == approx(lla[2])
+
+
+@pytest.mark.parametrize(
+    "xyz, lla",
+    xyz2lla_testsets
+)
+def test_numpy_ecef2geodetic(xyz, lla):
+    np = pytest.importorskip("numpy")
+    lat, lon, alt = pm.ecef2geodetic(*np.array([[xyz], ], dtype=np.float32).T)
+    assert lat[0] == approx(lla[0])
+    assert lon[0] == approx(lla[1])
+    assert alt[0] == approx(lla[2])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Explaination: on poles, ecef2geodetic does some tan(angle+eps), with
angle possibly close to pi/2 (or -pi/2). With float conversions,
angle+eps might be cast to float32 which does not work well with the
tan() discontinuities.

Illustration:
>>> print(pymap3d.ecef2geodetic(*np.array([[0,0,1]], dtype=np.float32).T, deg=1))
(array([-89.99999], dtype=float32), array([0.], dtype=float32), array([-6356751.5], dtype=float32))
>>> math.tan(np.float32(np.pi/2))
-22877332.42885646
>>> np.float32(np.pi/2) > np.pi/2
True

Fix logic: fix the latitude when we are on these edge cases.
These edge cases are identified using the float precision of the
parameters used.

Test modification: Using half the semiaxis for altitude change instead
of a single meter to not have test failures due to precision issues.