### PR TITLE
Geodetic to/from geocentric spherical conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ lookAtSpheroid
 track2 departure meanm
 rcurve rsphere
 geod2geoc geoc2geod
+geodetic2spherical spherical2geodetic
 ```
 
 Vincenty functions "vincenty.vreckon" and "vincenty.vdist" are accessed like:

--- a/src/pymap3d/__init__.py
+++ b/src/pymap3d/__init__.py
@@ -49,6 +49,7 @@ from .ecef import (
 from .sidereal import datetime2sidereal, greenwichsrt
 from .ellipsoid import Ellipsoid
 from .timeconv import str2dt
+from .spherical import spherical2geodetic, geodetic2spherical
 
 try:
     from .azelradec import radec2azel, azel2radec

--- a/src/pymap3d/spherical.py
+++ b/src/pymap3d/spherical.py
@@ -1,0 +1,183 @@
+"""
+Transformation of 3D coordinates between geocentric geodetic (latitude,
+longitude, height) and geocentric spherical (spherical latitude, longitude,
+radius).
+"""
+from __future__ import annotations
+
+try:
+    from numpy import (  # noqa: A001
+        radians,
+        sin,
+        arcsin as asin,
+        hypot,
+        degrees,
+        arctan2 as atan2,
+        sqrt,
+        cbrt,
+        power as pow,
+    )
+except ImportError:
+    from math import radians, sin, hypot, degrees, atan2, asin, sqrt  # type: ignore
+
+    def cbrt(x):  # type: ignore
+        "Backup cube root function in case of no numpy"
+        return x ** (1 / 3)
+
+from .ellipsoid import Ellipsoid
+from .utils import sanitize
+
+
+__all__ = [
+    "geodetic2spherical",
+    "spherical2geodetic",
+]
+
+
+def geodetic2spherical(
+    lat,
+    lon,
+    alt,
+    ell: Ellipsoid = None,
+    deg: bool = True,
+) -> tuple:
+    """
+    point transformation from Geodetic of specified ellipsoid (default WGS-84)
+    to geocentric spherical of the same ellipsoid
+
+    Parameters
+    ----------
+
+    lat
+           target geodetic latitude
+    lon
+           target geodetic longitude
+    h
+         target altitude above geodetic ellipsoid (meters)
+    ell : Ellipsoid, optional
+          reference ellipsoid
+    deg : bool, optional
+          degrees input/output  (False: radians in/out)
+
+
+    Returns
+    -------
+
+    Geocentric spherical (spherical latitude, longitude, radius
+
+    lat
+           target spherical latitude
+    lon
+           target longitude
+    radius
+         target distance to the geocenter (meters)
+
+    based on:
+    Vermeille, H., 2002. Direct transformation from geocentric coordinates to
+    geodetic coordinates. Journal of Geodesy. 76. 451-454.
+    doi:10.1007/s00190-002-0273-6
+    """
+    lat, ell = sanitize(lat, ell, deg)
+    if deg:
+        lon = radians(lon)
+
+    # Pre-compute to avoid repeated trigonometric functions
+    sinlat = sin(lat)
+    coslat = sqrt(1 - sinlat**2)
+
+    first_eccentricity = _calculate_first_eccentricity(ell)
+
+    # radius of curvature of the prime vertical section
+    N = ell.semimajor_axis**2 / hypot(
+        ell.semimajor_axis * coslat, ell.semiminor_axis * sinlat,
+    )
+
+    # Instead of computing X and Y, we only compute the projection on the XY
+    # plane: xy_projection = sqrt( X**2 + Y**2 )
+    xy_projection = (alt + N) * coslat
+    z_cartesian = (alt + (1 - first_eccentricity**2) * N) * sinlat
+    radius = hypot(xy_projection, z_cartesian)
+    slat = asin(z_cartesian / radius)
+
+    if deg:
+        slat = degrees(slat)
+        lon = degrees(lon)
+
+    return slat, lon, radius
+
+
+def spherical2geodetic(
+    lat,
+    lon,
+    radius,
+    ell: Ellipsoid = None,
+    deg: bool = True,
+) -> tuple:
+    """
+    point transformation from geocentric spherical of specified ellipsoid
+    (default WGS-84) to geodetic of the same ellipsoid
+
+    Parameters
+    ----------
+    lat
+           target spherical latitude
+    lon
+           target longitude
+    radius
+         target distance to the geocenter (meters)
+    ell : Ellipsoid, optional
+          reference ellipsoid
+    deg : bool, optional
+          degrees input/output  (False: radians in/out)
+
+    Returns
+    -------
+    lat
+           target geodetic latitude
+    lon
+           target geodetic longitude
+    alt
+         target altitude above geodetic ellipsoid (meters)
+
+    based on:
+    Vermeille, H., 2002. Direct transformation from geocentric coordinates to
+    geodetic coordinates. Journal of Geodesy. 76. 451-454.
+    doi:10.1007/s00190-002-0273-6
+    """
+    lat, ell = sanitize(lat, ell, deg)
+    if deg:
+        lon = radians(lon)
+
+    # Pre-compute to avoid repeated trigonometric functions
+    sinlat = sin(lat)
+    coslat = sqrt(1 - sinlat**2)
+
+    first_eccentricity = _calculate_first_eccentricity(ell)
+    Z = radius * sinlat
+    p_0 = pow(radius, 2) * coslat**2 / ell.semimajor_axis**2
+    q_0 = (1 - first_eccentricity**2) / ell.semimajor_axis**2 * Z**2
+    r_0 = (p_0 + q_0 - first_eccentricity**4) / 6
+    s_0 = first_eccentricity**4 * p_0 * q_0 / 4 / r_0**3
+    t_0 = cbrt(1 + s_0 + sqrt(2 * s_0 + s_0**2))
+    u_0 = r_0 * (1 + t_0 + 1 / t_0)
+    v_0 = sqrt(u_0**2 + q_0 * first_eccentricity**4)
+    w_0 = first_eccentricity**2 * (u_0 + v_0 - q_0) / 2 / v_0
+    k = sqrt(u_0 + v_0 + w_0**2) - w_0
+    D = k * radius * coslat / (k + first_eccentricity**2)
+    hypotDZ = hypot(D, Z)
+
+    glat = 2 * atan2(Z, (D + hypotDZ))
+    alt = (k + first_eccentricity**2 - 1) / k * hypotDZ
+
+    if deg:
+        glat = degrees(glat)
+        lon = degrees(lon)
+
+    return glat, lon, alt
+
+
+def _calculate_first_eccentricity(ell):
+    """
+    Calculate the first eccentricity of an ellipsoid.
+    """
+    return sqrt(ell.semimajor_axis**2 - ell.semiminor_axis**2) / ell.semimajor_axis

--- a/src/pymap3d/tests/test_spherical.py
+++ b/src/pymap3d/tests/test_spherical.py
@@ -1,0 +1,88 @@
+import pytest
+from pytest import approx
+
+try:
+    import numpy.array as nparray
+except ImportError:
+
+    def nparray(*args):
+        "dummy function to convert values to arrays"
+        return args
+
+import pymap3d as pm
+
+
+ELL = pm.Ellipsoid()
+A = ELL.semimajor_axis
+B = ELL.semiminor_axis
+
+llrlla = [
+    ((0, 0, A - 1), (0, 0, -1)),
+    ((0, 90, A - 1), (0, 90, -1)),
+    ((0, -90, A + 1), (0, -90, 1)),
+    ((44.807576814237606, 270, 6367490.543857), (45, 270, 1)),
+    ((90, 0, B + 1), (90, 0, 1)),
+    ((90, 15, B - 1), (90, 15, -1)),
+    ((-90, 0, B + 1), (-90, 0, 1)),
+]
+llallr = [
+    ((0, 0, -1), (0, 0, A - 1)),
+    ((0, 90, -1), (0, 90, A - 1)),
+    ((0, -90, 1), (0, -90, A + 1)),
+    ((45, 270, 1), (44.807576814237606, 270, 6367490.543857)),
+    ((90, 0, 1), (90, 0, B + 1)),
+    ((90, 15, -1), (90, 15, B - 1)),
+    ((-90, 0, 1), (-90, 0, B + 1)),
+]
+llallr_list = [([[i] for i in lla], llr) for lla, llr in llallr]
+llrlla_list = [([[i] for i in llr], lla) for llr, lla in llrlla]
+llallr_array = [([nparray(i) for i in lla], llr) for lla, llr in llallr]
+llrlla_array = [([nparray(i) for i in llr], lla) for llr, lla in llrlla]
+
+atol_dist = 1e-6  # 1 micrometer
+
+
+@pytest.mark.parametrize("lla, llr", llallr)
+def test_geodetic2spherical(lla, llr):
+    coords = pm.geodetic2spherical(*lla)
+    assert coords[:2] == approx(llr[:2])
+    assert coords[2] == approx(llr[2], abs=atol_dist)
+
+
+@pytest.mark.parametrize("llr, lla", llrlla)
+def test_spherical2geodetic(llr, lla):
+    coords = pm.spherical2geodetic(*llr)
+    assert coords[:2] == approx(lla[:2])
+    assert coords[2] == approx(lla[2], abs=atol_dist)
+
+
+@pytest.mark.parametrize("lla, llr", llallr_list)
+def test_geodetic2spherical_list(lla, llr):
+    pytest.importorskip("numpy")
+    coords = pm.geodetic2spherical(*lla)
+    assert coords[:2] == approx(llr[:2])
+    assert coords[2] == approx(llr[2], abs=atol_dist)
+
+
+@pytest.mark.parametrize("llr, lla", llrlla_list)
+def test_spherical2geodetic_list(llr, lla):
+    pytest.importorskip("numpy")
+    coords = pm.spherical2geodetic(*llr)
+    assert coords[:2] == approx(lla[:2])
+    assert coords[2] == approx(lla[2], abs=atol_dist)
+
+
+@pytest.mark.parametrize("lla, llr", llallr_array)
+def test_geodetic2spherical_array(lla, llr):
+    pytest.importorskip("numpy")
+    coords = pm.geodetic2spherical(*lla)
+    assert coords[:2] == approx(llr[:2])
+    assert coords[2] == approx(llr[2], abs=atol_dist)
+
+
+@pytest.mark.parametrize("llr, lla", llrlla_array)
+def test_spherical2geodetic_array(llr, lla):
+    pytest.importorskip("numpy")
+    coords = pm.spherical2geodetic(*llr)
+    assert coords[:2] == approx(lla[:2])
+    assert coords[2] == approx(lla[2], abs=atol_dist)


### PR DESCRIPTION
Add two functions to new module `pymap3d/spherical.py`:
`geodetic2spherical` and `spherical2geodetic` to convert between
geocentric geodetic (latitude, longitude, altitude) and geocentric
spherical coordinates (spherical latitude, longitude, radius).
Test against equator and pole easily deduced values as well as
latitude=45 with values pre-computed from the implementation in Boule.
Add the functions to the API definition in `pymap3d/__init__.py` and to
the list of functions in the `README.md`.

Fixes #54 