### PR TITLE
Add project URLs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,10 @@ classifiers =
   Topic :: Scientific/Engineering :: GIS
 license_files =
   LICENSE.txt
+project_urls =
+    Documentation = https://geospace-code.github.io/pymap3d
+    Source = https://github.com/geospace-code/pymap3d
+    Tracker = https://github.com/geospace-code/pymap3d/issues
 
 [options]
 python_requires = >= 3.7


### PR DESCRIPTION
These are visible in [Pymap3d's PyPI page](https://pypi.org/project/pymap3d/).

As an example, see the 'Project links' section in the left side-bar of [swf-typed's PyPI page](https://pypi.org/project/swf-typed/).