### PR TITLE
Build and publish sdist and wheel in CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,11 @@
+# GitHub Actions CI workflows
+Definitions for GitHub Actions (continuous integration) workflows
+
+## Publishing
+To publish a new version of the `pymap3d` package to PyPI, create and publish a
+release in GitHub (preferrably from a Git tag) for the version; the workflow
+will automatically build and publish an sdist and wheel from the tag.
+
+Requires the repo secret `PYPI_API_TOKEN` to be set to a PyPI API token: see
+[PyPI's help](https://pypi.org/help/#apitoken) for instructions on how to
+generate one.

--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -1,0 +1,32 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Update pip
+      run: pip install -U pip
+
+    - name: Install builder
+      run: pip install build
+
+    - name: Build package
+      run: pyproject-build --outdir dist/ .
+
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
See new [GitHub workflows README](https://github.com/EpicWink/pymap3d/blob/ci-build/.github/workflows/README.md) for instructions. This will build both sdist and wheel. PEP-517 build is now enabled