### PR TITLE
Add new ellipsoids, update ellipsoid tests

### DIFF
--- a/src/pymap3d/ellipsoid.py
+++ b/src/pymap3d/ellipsoid.py
@@ -6,11 +6,36 @@ class Ellipsoid:
     """
     generate reference ellipsoid parameters
 
-    https://en.wikibooks.org/wiki/PROJ.4#Spheroid
-
-    https://nssdc.gsfc.nasa.gov/planetary/factsheet/index.html
-
     as everywhere else in this program, distance units are METERS
+
+    Ellipsoid sources
+    -----------------
+
+    maupertuis, plessis, everest1830, everest1830m, everest1967,
+    airy, bessel, clarke1866, clarke1878, clarke1860, helmert, hayford,
+    international1924, krassovsky1940, wgs66, australian, international1967,
+    grs67, sa1969, wgs72, iers1989, iers2003:
+
+    - https://en.wikipedia.org/wiki/Earth_ellipsoid#Historical_Earth_ellipsoids
+    - https://en.wikibooks.org/wiki/PROJ.4#Spheroid
+
+    wgs84: https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84
+
+    grs80: https://en.wikipedia.org/wiki/GRS_80
+
+    io: https://doi.org/10.1006/icar.1998.5987
+
+    pz90.11: https://structure.mil.ru/files/pz-90.pdf
+
+    gsk2011: https://racurs.ru/downloads/documentation/gost_r_32453-2017.pdf
+
+    mars: https://tharsis.gsfc.nasa.gov/geodesy.html
+
+    mercury, venus, moon, jupiter, saturn, uranus, neptune:
+
+    - https://nssdc.gsfc.nasa.gov/planetary/factsheet/index.html
+
+    feel free to suggest additional ellipsoids
     """
 
     def __init__(self, model: str = "wgs84"):
@@ -23,49 +48,56 @@ class Ellipsoid:
                 name of ellipsoid
         """
 
-        if model == "wgs84":
-            """https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84"""
-            self.semimajor_axis = 6378137.0
-            self.semiminor_axis = 6356752.31424518
-        elif model == "wgs72":
-            self.semimajor_axis = 6378135.0
-            self.semiminor_axis = 6356750.52001609
-        elif model == "grs80":
-            """https://en.wikipedia.org/wiki/GRS_80"""
-            self.semimajor_axis = 6378137.0
-            self.semiminor_axis = 6356752.31414036
-        elif model == "clarke1866":
-            self.semimajor_axis = 6378206.4
-            self.semiminor_axis = 6356583.8
-        elif model == "mars":
-            """
-            https://tharsis.gsfc.nasa.gov/geodesy.html
-            """
-            self.semimajor_axis = 3396900.0
-            self.semiminor_axis = 3376097.80585952
-        elif model == "moon":
-            self.semimajor_axis = 1738000.0
-            self.semiminor_axis = self.semimajor_axis
-        elif model == "venus":
-            self.semimajor_axis = 6051000.0
-            self.semiminor_axis = self.semimajor_axis
-        elif model == "jupiter":
-            self.semimajor_axis = 71492000.0
-            self.semiminor_axis = 66770054.3475922
-        elif model == "io":
-            """
-            https://doi.org/10.1006/icar.1998.5987
-            """
-            self.semimajor_axis = 1829.7
-            self.semiminor_axis = 1815.8
-        elif model == "pluto":
-            self.semimajor_axis = 1187000.0
-            self.semiminor_axis = self.semimajor_axis
-        else:
+        models = {
+            # Earth ellipsoids
+            'maupertuis': {'name': 'Maupertuis (1738)', 'a': 6397300.0, 'b': 6363806.283},
+            'plessis': {'name': 'Plessis (1817)', 'a': 6376523.0, 'b': 6355862.9333},
+            'everest1830': {'name': 'Everest (1830)', 'a': 6377299.365, 'b': 6356098.359},
+            'everest1830m': {'name': 'Everest 1830 Modified (1967)', 'a': 6377304.063, 'b': 6356103.039},
+            'everest1967': {'name': 'Everest 1830 (1967 Definition)', 'a': 6377298.556, 'b': 6356097.55},
+            'airy': {'name': 'Airy (1830)', 'a': 6377563.396, 'b': 6356256.909},
+            'bessel': {'name': 'Bessel (1841)', 'a': 6377397.155, 'b': 6356078.963},
+            'clarke1866': {'name': 'Clarke (1866)', 'a': 6378206.4, 'b': 6356583.8},
+            'clarke1878': {'name': 'Clarke (1878)', 'a': 6378190.0, 'b': 6356456.0},
+            'clarke1860': {'name': 'Clarke (1880)', 'a': 6378249.145, 'b': 6356514.87},
+            'helmert': {'name': 'Helmert (1906)', 'a': 6378200.0, 'b': 6356818.17},
+            'hayford': {'name': 'Hayford (1910)', 'a': 6378388.0, 'b': 6356911.946},
+            'international1924': {'name': 'International (1924)', 'a': 6378388.0, 'b': 6356911.946},
+            'krassovsky1940': {'name': 'Krassovsky (1940)', 'a': 6378245.0, 'b': 6356863.019},
+            'wgs66': {'name': 'WGS66 (1966)', 'a': 6378145.0, 'b': 6356759.769},
+            'australian': {'name': 'Australian National (1966)', 'a': 6378160.0, 'b': 6356774.719},
+            'international1967': {'name': 'New International (1967)', 'a': 6378157.5, 'b': 6356772.2},
+            'grs67': {'name': 'GRS-67 (1967)', 'a': 6378160.0, 'b': 6356774.516},
+            'sa1969': {'name': 'South American (1969)', 'a': 6378160.0, 'b': 6356774.719},
+            'wgs72': {'name': 'WGS-72 (1972)', 'a': 6378135.0, 'b': 6356750.52001609},
+            'grs80': {'name': 'GRS-80 (1979)', 'a': 6378137.0, 'b': 6356752.31414036},
+            'wgs84': {'name': 'WGS-84 (1984)', 'a': 6378137.0, 'b': 6356752.31424518},
+            'iers1989': {'name': 'IERS (1989)', 'a': 6378136.0, 'b': 6356751.302},
+            "pz90.11": {'name': 'ПЗ-90 (2011)', 'a': 6378136.0, 'b': 6356751.3618},
+            'iers2003': {'name': 'IERS (2003)', 'a': 6378136.6, 'b': 6356751.9},
+            "gsk2011": {'name': 'ГСК (2011)', 'a': 6378136.5, 'b': 6356751.758},
+            # Other planets
+            "mercury": {'name': 'Mercury', 'a': 2440500.0, 'b': 2438300.0},
+            "venus": {"name": "Venus", "a": 6051800.0, "b": 6051800.0},
+            "moon": {"name": "Moon", "a": 1738100.0, "b": 1736000.0},
+            "mars": {"name": "Mars", "a": 3396900.0, "b": 3376097.80585952},
+            "jupyter": {"name": "Jupiter", "a": 71492000.0, "b": 66770054.3475922},
+            "io": {"name": "Io", "a": 1829.7, "b": 1815.8},
+            "saturn": {"name": "Saturn", "a": 60268000.0, "b": 54364301.5271271},
+            "uranus": {"name": "Uranus", "a": 25559000.0, "b": 24973000.0},
+            "neptune": {"name": "Neptune", "a": 24764000.0, "b": 24341000.0},
+            "pluto": {"name": "Pluto", "a": 1188000.0, "b": 1188000.0},
+        }
+
+        if model not in models:
             raise NotImplementedError(
                 f"{model} model not implemented, let us know and we will add it (or make a pull request)"
             )
 
+        self.model = model                 # short name
+        self.name = models[model]["name"]  # name for printing
+        self.semimajor_axis = models[model]['a']
+        self.semiminor_axis = models[model]['b']
         self.flattening = (self.semimajor_axis - self.semiminor_axis) / self.semimajor_axis
         self.thirdflattening = (self.semimajor_axis - self.semiminor_axis) / (
             self.semimajor_axis + self.semiminor_axis

--- a/src/pymap3d/tests/test_elliposid.py
+++ b/src/pymap3d/tests/test_elliposid.py
@@ -8,11 +8,39 @@ xyz0 = (660e3, -4700e3, 4247e3)
 @pytest.mark.parametrize(
     "model,f",
     [
-        ("wgs84", 3.352810664747480e-03),
-        ("wgs72", 3.352779454167505e-03),
-        ("grs80", 3.352810681182319e-03),
-        ("clarke1866", 3.390075303928791e-03),
-        ("moon", 0.0),
+        ("maupertuis", 0.005235602050865236),
+        ("plessis", 0.003240020729165458),
+        ("everest1830", 0.003324448922118313),
+        ("everest1830m", 0.003324449295589469),
+        ("everest1967", 0.003324449343845343),
+        ("airy", 0.00334085067870327),
+        ("bessel", 0.0033427731536659813),
+        ("clarke1866", 0.0033900753039287908),
+        ("clarke1878", 0.003407549790771363),
+        ("clarke1860", 0.003407561308111843),
+        ("helmert", 0.0033523298109184524),
+        ("hayford", 0.003367003387062615),
+        ("international1924", 0.003367003387062615),
+        ("krassovsky1940", 0.0033523298336767685),
+        ("wgs66", 0.0033528919458556804),
+        ("australian", 0.003352891899858333),
+        ("international1967", 0.003352896192983603),
+        ("grs67", 0.0033529237272191623),
+        ("sa1969", 0.003352891899858333),
+        ("wgs72", 0.0033527794541680267),
+        ("grs80", 0.0033528106811816882),
+        ("wgs84", 0.0033528106647473664),
+        ("iers1989", 0.0033528131102879993),
+        ("iers2003", 0.0033528131084554157),
+        ("mercury", 0.0009014546199549272),
+        ("venus", 0.0),
+        ("moon", 0.0012082158679017317),
+        ("mars", 0.006123875928193323),
+        ("jupyter", 0.06604858798757626),
+        ("io", 0.0075968738044488665),
+        ("uranus", 0.022927344575296372),
+        ("neptune", 0.01708124697141011),
+        ("pluto", 0.0),
     ],
 )
 def test_reference(model, f):
@@ -21,21 +49,102 @@ def test_reference(model, f):
 
 def test_ellipsoid():
 
-    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("wgs84")) == approx(
-        [42.014670535, -82.0064785, 276.9136916]
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("maupertuis")) == approx(
+        [42.123086280313906, -82.00647850636021, -13462.822154350226]
     )
-    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("grs80")) == approx(
-        [42.014670536, -82.0064785, 276.9137385]
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("plessis")) == approx(
+        [42.008184833614905, -82.00647850636021, 1566.9219075104988]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("everest1830")) == approx(
+        [42.01302648557789, -82.00647850636021, 1032.4153744896425]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("everest1830m")) == approx(
+        [42.0130266467127, -82.00647850636021, 1027.7254294115853]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("everest1967")) == approx(
+        [42.01302648557363, -82.00647850636021, 1033.2243733811288]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("airy")) == approx(
+        [42.01397060398504, -82.00647850636021, 815.5499438015993]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("bessel")) == approx(
+        [42.01407537004288, -82.00647850636021, 987.0246149983182]
     )
     assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("clarke1866")) == approx(
-        [42.01680003, -82.0064785, 313.9026793]
+        [42.01680003414445, -82.00647850636021, 313.90267925120395]
     )
-    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("mars")) == approx(
-        [42.009428417, -82.006479, 2.981246e6]
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("clarke1878")) == approx(
+        [42.0177971504227, -82.00647850636021, 380.12002203958457]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("clarke1860")) == approx(
+        [42.017799612218326, -82.00647850636021, 321.0980872430816]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("helmert")) == approx(
+        [42.01464497456125, -82.00647850636021, 212.63680219872765]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("hayford")) == approx(
+        [42.01548834310426, -82.00647850636021, 66.77070154259877]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("international1924")) == approx(
+        [42.01548834310426, -82.00647850636021, 66.77070154259877]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("krassovsky1940")) == approx(
+        [42.01464632634865, -82.00647850636021, 167.7043859419633]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("wgs66")) == approx(
+        [42.014675415414274, -82.00647850636021, 269.1575142686737]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("australian")) == approx(
+        [42.01467586302664, -82.00647850636021, 254.17989315657786]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("international1967")) == approx(
+        [42.01467603307557, -82.00647850636021, 256.6883857005818]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("grs67")) == approx(
+        [42.01467768000789, -82.00647850636021, 254.27066653452297]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("sa1969")) == approx(
+        [42.01467586302664, -82.00647850636021, 254.17989315657786]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("wgs72")) == approx(
+        [42.01466869328149, -82.00647850636021, 278.8216763935984]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("grs80")) == approx(
+        [42.01467053601299, -82.00647850636021, 276.9137384511387]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("wgs84")) == approx(
+        [42.01467053507479, -82.00647850636021, 276.91369158042767]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("iers1989")) == approx(
+        [42.01467064467172, -82.00647850636021, 277.9191657339711]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("iers2003")) == approx(
+        [42.01467066257621, -82.00647850636021, 277.320060889772]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("mercury")) == approx(
+        [41.8430384333997, -82.00647850636021, 3929356.5648451606]
     )
     assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("venus")) == approx(
-        [41.8233663, -82.0064785, 3.17878159e5]
+        [41.82336630167669, -82.00647850636021, 317078.15867127385]
     )
     assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("moon")) == approx(
-        [41.8233663, -82.0064785, 4.630878e6]
+        [41.842147614909734, -82.00647850636021, 4631711.995926845]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("mars")) == approx(
+        [42.00945156056578, -82.00647850636021, 2981246.073616111]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("jupyter")) == approx(
+        [75.3013267078341, -82.00647850636021, -61782040.202975556]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("io")) == approx(
+        [41.82422244977044, -82.00647850636021, 6367054.626528843]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("uranus")) == approx(
+        [47.69837228395133, -82.00647850636021, -18904824.4361074]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("neptune")) == approx(
+        [45.931317431546425, -82.00647850636021, -18194050.781948525]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("pluto")) == approx(
+        [41.82336630167669, -82.00647850636021, 5180878.158671274]
     )


### PR DESCRIPTION
This PR adds many new ellipsoids for the Earth and other planets of the Solar system. It also adds tests for new ellipsoids. 

The parameters are taken from Wikipedia and official documents (the documentation is supplemented with links to the source for each ellipsoid).

All pre-existing Earth ellipsoids (and their parameters) remain the same. I slightly adjusted the parameters of the Moon and Venus ellipsoids according to [NASA Planetary Fact Sheet](https://nssdc.gsfc.nasa.gov/planetary/factsheet/index.html). 