### PR TITLE
Add new spherical ellipsoid

### DIFF
--- a/src/pymap3d/ellipsoid.py
+++ b/src/pymap3d/ellipsoid.py
@@ -61,6 +61,10 @@ class Ellipsoid:
         elif model == "pluto":
             self.semimajor_axis = 1187000.0
             self.semiminor_axis = self.semimajor_axis
+        elif model == "wgs84_mean":
+            """https://en.wikipedia.org/wiki/Earth_radius#Mean_radii"""
+            self.semimajor_axis = 6371008.7714
+            self.semiminor_axis = self.semimajor_axis
         else:
             raise NotImplementedError(
                 f"{model} model not implemented, let us know and we will add it (or make a pull request)"

--- a/src/pymap3d/tests/test_ellipsoid.py
+++ b/src/pymap3d/tests/test_ellipsoid.py
@@ -1,6 +1,6 @@
+import pymap3d as pm
 import pytest
 from pytest import approx
-import pymap3d as pm
 
 xyz0 = (660e3, -4700e3, 4247e3)
 
@@ -9,6 +9,7 @@ xyz0 = (660e3, -4700e3, 4247e3)
     "model,f",
     [
         ("wgs84", 3.352810664747480e-03),
+        ("wgs84_mean", 0.0),
         ("wgs72", 3.352779454167505e-03),
         ("grs80", 3.352810681182319e-03),
         ("clarke1866", 3.390075303928791e-03),
@@ -23,6 +24,9 @@ def test_ellipsoid():
 
     assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("wgs84")) == approx(
         [42.014670535, -82.0064785, 276.9136916]
+    )
+    assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("wgs84_mean")) == approx(
+        [41.823366301, -82.0064785, -2.13061272e3]
     )
     assert pm.ecef2geodetic(*xyz0, ell=pm.Ellipsoid("grs80")) == approx(
         [42.014670536, -82.0064785, 276.9137385]


### PR DESCRIPTION
Added new spherical projection of Earth based on WGS-84 ellipsoid, Mean radius of semi-axes (R1) equal to `6371008.7714` meters.
Named it `wg84_mean` but I'm open to suggestions (`wgs84_sphere`, `wgs84_spherical`, `earth_sphere`, ...)
More info: https://en.wikipedia.org/wiki/Earth_radius#Mean_radii

Additionally, changed typo in the `test_elliposid.py` file name.