### PR TITLE
Fixed divide-by-zero errors in ecef2geodetic caused by changes in 3.0.0 release.

### DIFF
--- a/src/pymap3d/ecef.py
+++ b/src/pymap3d/ecef.py
@@ -148,7 +148,7 @@ def ecef2geodetic(
             warnings.simplefilter("error")
             Beta = atan(huE / u * z / hypot(x, y))
     except (ArithmeticError, RuntimeWarning):
-        if isclose(z, 0):
+        if any(isclose(z, 0)):
             Beta = 0
         elif z > 0:
             Beta = pi / 2

--- a/src/pymap3d/ecef.py
+++ b/src/pymap3d/ecef.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import warnings
 
 try:
-    from numpy import asarray, finfo, where
+    from numpy import asarray, finfo, full_like, logical_and, logical_or, ndarray, where
 
     from .eci import ecef2eci, eci2ecef
 except ImportError:
@@ -144,16 +144,24 @@ def ecef2geodetic(
 
     # eqn. 4b
     try:
+        calculated_idx = full_like(z, False)
+        Beta = ndarray(z.shape)
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("error")
-            Beta = atan(huE / u * z / hypot(x, y))
+            # Preempt any possible divide-by-zero errors by only calculating values that will succeed. Then, below, use
+            # the fallback Beta values for any values that would have failed.
+            xy_hypot = hypot(x, y)
+            calculated_idx = ~logical_or(isclose(u, 0), isclose(xy_hypot, 0))
+            Beta[calculated_idx] = atan(huE[calculated_idx] / u[calculated_idx] * z[calculated_idx] /
+                                        xy_hypot[calculated_idx])
     except (ArithmeticError, RuntimeWarning):
-        if any(isclose(z, 0)):
-            Beta = 0
-        elif z > 0:
-            Beta = pi / 2
-        else:
-            Beta = -pi / 2
+        pass
+
+    if not all(calculated_idx):
+        not_calculated_idx = ~calculated_idx
+        Beta[logical_and(not_calculated_idx, z > 0)] = pi / 2
+        Beta[logical_and(not_calculated_idx, z < 0)] = -pi / 2
+        Beta[logical_and(not_calculated_idx, isclose(z, 0))] = 0
 
     # eqn. 13
     dBeta = ((ell.semiminor_axis * u - ell.semimajor_axis * huE + E**2) * sin(Beta)) / (


### PR DESCRIPTION
After the recent change to use `isclose()` in commit dde1b9c, `ecef2geodetic` now raises `ValueError` if you try to convert more than one position, and at least one of those results in a divide-by-zero error. This fixes that, and also fixes the `Beta` value used for all positions that did _not_ have a divide-by-zero error.