### PR TITLE
chore: correct docstrings

### DIFF
--- a/src/pymap3d/aer.py
+++ b/src/pymap3d/aer.py
@@ -287,7 +287,7 @@ def aer2ecef(
            Observer geodetic latitude
     lon0 : float
            Observer geodetic longitude
-    h0 : float
+    alt0 : float
          observer altitude above geodetic ellipsoid (meters)
     ell : Ellipsoid, optional
           reference ellipsoid

--- a/src/pymap3d/ecef.py
+++ b/src/pymap3d/ecef.py
@@ -48,7 +48,7 @@ def geodetic2ecef(
            target geodetic latitude
     lon
            target geodetic longitude
-    h
+    alt
          target altitude above geodetic ellipsoid (meters)
     ell : Ellipsoid, optional
           reference ellipsoid
@@ -226,8 +226,6 @@ def ecef2enuv(u, v, w, lat0, lon0, deg: bool = True) -> tuple:
            Observer geodetic latitude
     lon0
            Observer geodetic longitude
-    h0
-         observer altitude above geodetic ellipsoid (meters)
     deg : bool, optional
           degrees input/output  (False: radians in/out)
 
@@ -312,12 +310,18 @@ def enu2uvw(
     Parameters
     ----------
 
-    e1
+    east
         target east ENU coordinate (meters)
-    n1
+    north
         target north ENU coordinate (meters)
-    u1
+    up
         target up ENU coordinate (meters)
+    lat0
+           Observer geodetic latitude
+    lon0
+           Observer geodetic longitude
+    deg : bool, optional
+          degrees input/output  (False: radians in/out)
 
     Results
     -------
@@ -346,9 +350,17 @@ def uvw2enu(u, v, w, lat0, lon0, deg: bool = True) -> tuple:
     ----------
 
     u
+        target x ECEF coordinate (meters)
     v
+        target y ECEF coordinate (meters)
     w
-
+        target z ECEF coordinate (meters)
+    lat0
+           Observer geodetic latitude
+    lon0
+           Observer geodetic longitude
+    deg : bool, optional
+          degrees input/output  (False: radians in/out)
 
     Results
     -------

--- a/src/pymap3d/enu.py
+++ b/src/pymap3d/enu.py
@@ -74,9 +74,9 @@ def aer2enu(az, el, srange, deg: bool = True) -> tuple:
 
     Parameters
     ----------
-    azimuth : float
+    az : float
             azimuth clockwise from north (degrees)
-    elevation : float
+    el : float
         elevation angle above horizon, neglecting aberrations (degrees)
     srange : float
         slant range [meters]

--- a/src/pymap3d/latitude.py
+++ b/src/pymap3d/latitude.py
@@ -175,7 +175,7 @@ def geodetic2isometric(geodetic_lat, ell: Ellipsoid = None, deg: bool = True):
 
     Parameters
     ----------
-    lat : float
+    geodetic_lat : float
          geodetic latitude
     ell : Ellipsoid, optional
          reference ellipsoid (default WGS84)

--- a/src/pymap3d/rsphere.py
+++ b/src/pymap3d/rsphere.py
@@ -146,15 +146,15 @@ def curve(lat, ell: Ellipsoid = None, deg: bool = True, method: str = "mean"):
 
     Parameters
     ----------
-    lat1 : float
+    lat : float
         geodetic latitudes (degrees)
     ell : Ellipsoid, optional
           reference ellipsoid
-    method: str, optional
-        "mean" or "norm"
     deg : bool, optional
           degrees input/output  (False: radians in/out)
-
+    method: str, optional
+        "mean" or "norm"
+        
     Returns
     -------
     radius: float

--- a/src/pymap3d/spherical.py
+++ b/src/pymap3d/spherical.py
@@ -33,7 +33,7 @@ def geodetic2spherical(
            target geodetic latitude
     lon
            target geodetic longitude
-    h
+    alt
          target altitude above geodetic ellipsoid (meters)
     ell : Ellipsoid, optional
           reference ellipsoid

--- a/src/pymap3d/vincenty.py
+++ b/src/pymap3d/vincenty.py
@@ -478,13 +478,13 @@ def track2(
     Parameters
     ----------
 
-    Lat1 : float
+    lat1 : float
         Geodetic latitude of first point (degrees)
-    Lon1 : float
+    lon1 : float
         Geodetic longitude of first point (degrees)
-    Lat2 : float
+    lat2 : float
         Geodetic latitude of second point (degrees)
-    Lon2 : float
+    lon2 : float
         Geodetic longitude of second point (degrees)
     ell : Ellipsoid, optional
           reference ellipsoid


### PR DESCRIPTION
I noted locations in the codebase where arguments differ from the docstrings. This PR corrects those issues in:

- aer.py
- ecef.py
- enu.py
- latitude.py
- rsphere.py
- spherical.py
- vincenty.py