### PR TITLE
Adding reference to cpp port of pymap3d

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Thanks to our [contributors](./.github/contributors.md).
 * [Matlab, GNU Octave](https://github.com/geospace-code/matmap3d)
 * [Fortran](https://github.com/geospace-code/maptran3d)
 * [Rust](https://github.com/gberrante/map_3d)
+* [C++](https://github.com/ClancyWalters/cppmap3d)
 
 ## Prerequisites
 


### PR DESCRIPTION
I wrote a port of pymap3d for cpp since I couldn't find something similar, might be worth linking. I ported over all the unit tests from both pymap3d and rust map3d.