### PR TITLE
fix: normalize vreckon output longitude to [-180, 180] range

### DIFF
--- a/src/pymap3d/tests/test_vincenty_vreckon.py
+++ b/src/pymap3d/tests/test_vincenty_vreckon.py
@@ -23,11 +23,11 @@ az3 = (218.00292856, 225.0011203)
     [
         (0, 0, 0, 0, 0, 0),
         (0, 0, 1.001875e7, 90, 0, 90),
-        (0, 0, 1.001875e7, 270, 0, 270),
-        (0, 0, 1.001875e7, -90, 0, 270),
+        (0, 0, 1.001875e7, 270, 0, -90),
+        (0, 0, 1.001875e7, -90, 0, -90),
         (0, 0, 2.00375e7, 90, 0, 180),
-        (0, 0, 2.00375e7, 270, 0, 180),
-        (0, 0, 2.00375e7, -90, 0, 180),
+        (0, 0, 2.00375e7, 270, 0, -180),
+        (0, 0, 2.00375e7, -90, 0, -180),
     ],
 )
 def test_vreckon_unit(deg, lat, lon, srange, az, lato, lono):
@@ -41,6 +41,15 @@ def test_vreckon_unit(deg, lat, lon, srange, az, lato, lono):
 
     assert lon1 == approx(lono, rel=0.001)
     assert isinstance(lon1, float)
+
+
+def test_negative_lon_stays_negative():
+    """Regression test for issue #88: vreckon with negative start longitude
+    must return a negative (or near-zero) destination longitude, not 358+."""
+    lat2, lon2 = vincenty.vreckon(52.22610277777778, -1.2696583333333333, 839.63, 63.02)
+    assert lat2 == approx(52.22952562862266, rel=1e-6)
+    assert -180 <= lon2 <= 0, f"lon2={lon2} should be negative for a point west of prime meridian"
+    assert lon2 == approx(-1.258707, abs=1e-3)
 
 
 def test_az_vector():

--- a/src/pymap3d/vincenty.py
+++ b/src/pymap3d/vincenty.py
@@ -433,7 +433,7 @@ def vreckon(
     #    lon2 = pi*((absolute(lon2)/pi) -
     #       2*ceil(((absolute(lon2)/pi)-1)/2)) * sign(lon2)
 
-    lon2 %= tau  # follow [0, 360) convention
+    lon2 = (lon2 + pi) % tau - pi  # normalize to [-180, 180) convention
 
     if deg:
         lat2 = degrees(lat2)


### PR DESCRIPTION
## Summary

Fixes #88.

`vreckon()` wrapped the computed destination longitude with `lon2 %= tau`, producing values in **[0, 360)**. Any starting longitude west of the prime meridian therefore returned a wrong result — e.g. the example in #88:

```python
>>> pymap3d.vincenty.vreckon(52.2261, -1.2697, 839.63, 63.02)
(52.22952..., 358.7413...)  # lon should be near -1.26°, not 358.74°
```

The comment added by Joaquim Luis already stated: *"lon2 is always converted to the \[-180 180\] interval"* — the implementation simply didn't match that intent.

## Fix

One-line change in `vincenty.py`:

```python
# before
lon2 %= tau                          # [0, 360)
# after
lon2 = (lon2 + pi) % tau - pi       # [-180, 180)
```

Four existing test expectations that encoded the old `[0, 360)` behaviour are updated (e.g. west-quadrant output `270°` → `-90°`), and a regression test for the exact case in #88 is added.

All 396 tests pass (9 skipped for missing optional deps).

## Test plan

- [x] `pytest src/pymap3d/tests/test_vincenty_vreckon.py` — 17/17 pass (incl. new regression)
- [x] `pytest src/pymap3d/tests/test_vincenty_dist.py` — 16/16 pass
- [x] Full suite (`pytest src/pymap3d/tests/ -q`) — 396 passed, 9 skipped

This pull request was prepared with the assistance of AI, under my direction and review.